### PR TITLE
feat: cmd to merge multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - Specify custom delimiters for CSV files
 - Infer and convert column types (string to integer or float)
 - Specify output file name or path
+- Merge multiple CSV files into a single Excel file
 
 ## Installation
 
@@ -32,6 +33,20 @@ csv2excel -i <input-file> -o <output-file> -d <delimiter> -c
 - `-i, --input`: Path to the input CSV file (required)
 - `-o, --output`: Path to the output Excel file (optional)
 - `-n, --name`: Name of the output Excel file (optional)
+- `-d, --delimiter`: Delimiter for CSV file (default is `,`)
+- `-c, --convert`: Convert column types to inferred types (optional)
+
+### Merge Command Options
+
+The `merge` command allows you to combine multiple CSV files into a single Excel file. Below are the available options:
+
+```sh
+csv2excel merge -f <file1.csv,file2.csv> -F <folder> -o <output-file> -d <delimiter> -c
+```
+
+- `-f, --files`: List of CSV files to merge (comma-separated)
+- `-F, --folder`: Path to the folder containing CSV files
+- `-o, --output`: Path to the output Excel file (required)
 - `-d, --delimiter`: Delimiter for CSV file (default is `,`)
 - `-c, --convert`: Convert column types to inferred types (optional)
 
@@ -59,6 +74,18 @@ Specify the full path for the output file:
 
 ```sh
 csv2excel -i data.csv -o /path/to/output.xlsx
+```
+
+Merge multiple CSV files into a single Excel file:
+
+```sh
+csv2excel merge -f file1.csv,file2.csv -o merged.xlsx
+```
+
+Merge all CSV files in a folder into a single Excel file:
+
+```sh
+csv2excel merge -F /path/to/csvfiles -o merged.xlsx
 ```
 
 ## License

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -1,6 +1,3 @@
-/*
-Copyright © 2024 NAME HERE <EMAIL ADDRESS>
-*/
 package cmd
 
 import (

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -1,0 +1,160 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	file "github.com/HampB/csv2excel/internal"
+	"github.com/spf13/cobra"
+)
+
+// mergeCmd represents the merge command
+var (
+	inputFiles  []string
+	inputFolder string
+
+	mergeCmd = &cobra.Command{
+		Use:   "merge",
+		Short: "Merge multiple CSV files into a single Excel file",
+		Long: `The merge command allows you to combine multiple CSV files into a single Excel file.
+You can specify individual CSV files or a folder containing CSV files. For example:
+
+csv2excel merge --files file1.csv,file2.csv --output result.xlsx
+csv2excel merge --folder /path/to/csvfiles --output result.xlsx`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if delimiter == "" {
+				fmt.Println("Delimiter cannot be empty")
+				return
+			}
+			delimiterRune := []rune(delimiter)[0]
+
+			if inputFolder != "" {
+				var err error
+				inputFiles, err = createFileList(inputFolder)
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
+			}
+
+			f, err := processFiles(inputFiles, delimiterRune)
+
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+
+			if convertTypes {
+				f.ConvertColumnTypes()
+			}
+			if outputFile == "" && outputName == "" {
+				outputFile = strings.Replace(inputFile, ".csv", ".xlsx", 1)
+			}
+			if outputName != "" {
+				outputFile = filepath.Join(filepath.Dir(inputFile), outputName+".xlsx")
+			}
+			if _, err := os.Stat(filepath.Dir(outputFile)); os.IsNotExist(err) {
+				fmt.Printf("Invalid output path: %s\n", filepath.Dir(outputFile))
+				return
+			}
+			err = f.SaveAsExcel(outputFile, "Sheet1")
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Printf("Successfully converted %d records with %d columns to %s\n", len(f.Records), len(f.Headers), outputFile)
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(mergeCmd)
+
+	mergeCmd.Flags().StringSliceVarP(&inputFiles, "files", "f", []string{}, "List of CSV files to merge")
+	mergeCmd.Flags().StringVarP(&inputFolder, "folder", "F", "", "Path to the folder containing CSV files")
+	mergeCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Path to the output Excel file")
+	mergeCmd.Flags().StringVarP(&delimiter, "delimiter", "d", ",", "Delimiter for CSV file")
+	mergeCmd.Flags().BoolVarP(&convertTypes, "convert", "c", false, "Convert column types to inferred types")
+
+	mergeCmd.MarkFlagsOneRequired("files", "folder")
+	mergeCmd.MarkFlagsMutuallyExclusive("files", "folder")
+	mergeCmd.MarkFlagRequired("output")
+}
+
+// processFiles reads and processes multiple CSV files concurrently.
+// It takes a slice of file paths and a delimiter as input, and returns a merged CSV file or an error.
+func processFiles(filePaths []string, delimiter rune) (*file.CSV, error) {
+	wg := sync.WaitGroup{}
+	resultChannel := make(chan processResult)
+
+	for _, filePath := range filePaths {
+		filePath = strings.TrimSpace(filePath)
+		if !strings.HasSuffix(filePath, ".csv") {
+			return nil, fmt.Errorf("invalid input file format. Please provide a CSV file")
+		}
+		wg.Add(1)
+		go func(filePath string, delimiter rune) {
+			defer wg.Done()
+			f := file.New(filePath, delimiter)
+			err := f.Read()
+			if err != nil {
+				resultChannel <- processResult{err: err}
+				return
+			}
+			resultChannel <- processResult{file: f}
+		}(filePath, delimiter)
+	}
+	go func() {
+		wg.Wait()
+		close(resultChannel)
+	}()
+	var errors []error
+	var files = make([]*file.CSV, 0, len(filePaths))
+	for result := range resultChannel {
+		if result.err != nil {
+			errors = append(errors, result.err)
+		} else {
+			files = append(files, result.file)
+		}
+	}
+
+	if len(errors) > 0 {
+		return nil, fmt.Errorf("encountered errors while reading files: %v", errors)
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no valid CSV files to merge")
+	}
+	return file.Merge(files...)
+
+}
+
+// processResult represents the result of processing a CSV file.
+// It contains a pointer to the processed CSV file and an error, if any occurred during processing.
+type processResult struct {
+	file *file.CSV
+	err  error
+}
+
+// createFileList scans the specified folder for files with a .csv extension
+// and returns a slice of their file paths. If an error occurs during reading
+// the directory, it returns the error.
+func createFileList(folderPath string) ([]string, error) {
+	var files []string
+	entries, err := os.ReadDir(folderPath)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".csv") {
+			files = append(files, filepath.Join(folderPath, entry.Name()))
+		}
+	}
+	return files, nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,7 +73,6 @@ func Execute() {
 
 func init() {
 
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.Flags().StringVarP(&inputFile, "input", "i", "", "Path to the input CSV file")
 	rootCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Path to the output Excel file")
 	rootCmd.Flags().StringVarP(&outputName, "name", "n", "", "Name of the output Excel file")

--- a/internal/file.go
+++ b/internal/file.go
@@ -199,7 +199,7 @@ func Merge(files ...*CSV) (*CSV, error) {
 
 	for _, file := range files[1:] {
 		if columnCount != len(file.Headers) {
-			return nil, fmt.Errorf("inconsistent number of columns in files")
+			return nil, fmt.Errorf("inconsistent number of columns in either %s or %s", file.FilePath, files[0].FilePath)
 		}
 	}
 	mergedFiles := make([][]interface{}, 0)


### PR DESCRIPTION
This pull request introduces a new feature to merge multiple CSV files into a single Excel file. The most important changes include  the addition of the `merge` command in the command-line interface, and the implementation of the merging logic in the codebase.

### Command-Line Interface:
* [`cmd/merge.go`](diffhunk://#diff-bdb4541ce0bce010440e1e9480d41fd7f445215238030c5a6cf3f2cee9b677a7R1-R160): Introduced the `merge` command to the CLI, allowing users to specify individual CSV files or a folder containing CSV files to merge into a single Excel file.

### Code Implementation:
* [`internal/file.go`](diffhunk://#diff-9843603cd46144cc8217996557189bc34d026f6740d54dafb7c2c76925fdf835R56-R71): Added a new function `Merge` to handle the merging of multiple CSV files and a constructor `NewFromRecords` to create a `CSV` object from records. [[1]](diffhunk://#diff-9843603cd46144cc8217996557189bc34d026f6740d54dafb7c2c76925fdf835R56-R71) [[2]](diffhunk://#diff-9843603cd46144cc8217996557189bc34d026f6740d54dafb7c2c76925fdf835R193-R211)